### PR TITLE
Used strong comparison and prevented remote selection of hash algorithm

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -87,7 +87,13 @@ class Handler
     protected function validateSignature($gitHubSignatureHeader, $payload)
     {
         list ($algo, $gitHubSignature) = explode("=", $gitHubSignatureHeader);
+
+        if ($algo !== 'sha1') {
+            // see https://developer.github.com/webhooks/securing/
+            return false;
+        }
+
         $payloadHash = hash_hmac($algo, $payload, $this->secret);
-        return ($payloadHash == $gitHubSignature);
+        return ($payloadHash === $gitHubSignature);
     }
 }


### PR DESCRIPTION
The comparison of strings should be strict to prevent this bug: https://3v4l.org/0KPn4

Also, at the moment GitHub only use SHA-1 for signing payloads. Allowing the sender of the payload to pick the hashing algorithm free format creates an opportunity to use a weaker algorithm when carrying out a brute force attack (such as one exploiting the weak string comparison).
