### PR TITLE
Allow both json and url encoded payloads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ repository, and click on **Webhooks & services**. After that, click on **Add web
 
 Fill in following values in form:
 * **Payload URL** - Enter full URL to your webhook script
-* **Content type** - should be "application/json"
-* **Secret** - same secret you pass to constructor of `Handler` object
+* **Content type** - Can be either "application/json" or "application/x-www-form-urlencoded"
+* **Secret** - Same secret you pass to constructor of `Handler` object
 * Webhook should receive only push events and of course be active
 
 Click **Add webhook** button and that's it.

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -74,10 +74,16 @@ class Handler
         $signature = @$_SERVER['HTTP_X_HUB_SIGNATURE'];
         $event = @$_SERVER['HTTP_X_GITHUB_EVENT'];
         $delivery = @$_SERVER['HTTP_X_GITHUB_DELIVERY'];
-        $payload = file_get_contents('php://input');
 
         if (!isset($signature, $event, $delivery)) {
             return false;
+        }
+
+        $payload = file_get_contents('php://input');
+
+        // Check if the payload is json or urlencoded.
+        if (strpos($payload, 'payload=') === 0) {
+            $payload = substr(urldecode($payload), 8);
         }
 
         if (!$this->validateSignature($signature, $payload)) {


### PR DESCRIPTION
A simple addition that allows both content types to be handled.

(I saw there are no comments in your code, but I thought I'd add one to explain)